### PR TITLE
Ongoing Development

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -14,7 +14,7 @@ jobs:
         python-version: 3.9
     - name: Install Dependencies
       run: |
-        pip install mypy types-setuptools
+        pip install mypy types-setuptools types-docutils
     - name: mypy
       run: |
         mypy src

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## 1.0a1 (unreleased)
 
+- Conditional add local [requirement|constraints}.txt to LOCAL_PACKAGE_FILES.
+
 - Generate one Makefile from snippets instead of including several files from
   subfolder.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## 1.0a1 (unreleased)
 
+- Create `scss` domain in `js` topic.
+
+- Create `gettext` domain in `i18n` topic.
+
+- Create `lingua` domain in `i18n` topic.
+
 - Conditional add local [requirement|constraints}.txt to LOCAL_PACKAGE_FILES.
 
 - Generate one Makefile from snippets instead of including several files from

--- a/Makefile
+++ b/Makefile
@@ -346,16 +346,7 @@ else
 	@echo "[settings]" > $(PROJECT_CONFIG)
 endif
 
-LOCAL_PACKAGE_FILES:=
-ifneq ("$(wildcard pyproject.toml)","")
-	LOCAL_PACKAGE_FILES+=pyproject.toml
-endif
-ifneq ("$(wildcard setup.cfg)","")
-	LOCAL_PACKAGE_FILES+=setup.cfg
-endif
-ifneq ("$(wildcard setup.py)","")
-	LOCAL_PACKAGE_FILES+=setup.py
-endif
+LOCAL_PACKAGE_FILES:=$(wildcard pyproject.toml setup.cfg setup.py requirements.txt constraints.txt)
 
 FILES_TARGET:=requirements-mxdev.txt
 $(FILES_TARGET): $(PROJECT_CONFIG) $(MXENV_TARGET) $(SOURCES_TARGET) $(LOCAL_PACKAGE_FILES)

--- a/docs/source/extending.md
+++ b/docs/source/extending.md
@@ -109,10 +109,14 @@ The following naming should be taken into account:
 
 #### The domain sentinel
 
-Since make keeps track of file modification timestamps, installation related targets should be bound to some installation related file(s).
+Since *make* keeps track of file modification timestamps, installation related targets should be bound to some installation related file(s).
 This ensures that targets are not run if not necessary.
-Sometimes there are no reliable files to depend on, therefor sentinel files are used.
-They are created during installation, and removed on `dirty` and `clean`, to mimic the behavior of depending on "real" domain related files.
+
+```{note}
+Sometimes there are no reliable files created to depend on, therefor sentinel files are used.
+```
+
+[Sentinel files](make-sentinel-files) are created during installation, and removed on `dirty` and `clean`, to mimic the behavior of depending on "real" domain related files.
 
 The basic pattern for using a sentinel file is shown here by installing a python package with pip:
 

--- a/docs/source/make.md
+++ b/docs/source/make.md
@@ -39,6 +39,8 @@ Phony targets are useful because they provide a way to define targets that don't
 Additionally, "make" considers phony targets to always be out-of-date, so the commands for a phony target will always be executed, even if its dependencies are up-to-date.
 This can be useful when you want to guarantee that an action is performed, such as cleaning the build directory before a build.
 
+(make-sentinel-files)=
+
 ## Sentinel files
 
 Tracking the state of a target in "make" is typically done by checking the timestamp of a file that is the output of a particular step.

--- a/docs/source/make.md
+++ b/docs/source/make.md
@@ -13,10 +13,6 @@ In "make", dependency management is achieved through the use of rules and depend
 A rule defines a target, its dependencies, and the commands necessary to create the target.
 The dependencies for a target specify the other files that it relies on and must be built before the target can be built.
 
-In "make", dependency management is achieved through the use of rules and dependencies.
-A rule defines a target, its dependencies, and the commands necessary to build the target.
-The dependencies for a target specify the other files that it relies on and must be built before the target can be built.
-
 When "make" is run, it checks the timestamps of the target and its dependencies.
 If the target is older than its dependencies, "make" will run the commands in the rule to rebuild the target.
 If the dependencies are up-to-date, "make" will skip the build process for the target, saving time and resources.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ ldap = "mxmake.topics:ldap"
 qa = "mxmake.topics:qa"
 system = "mxmake.topics:system"
 applications = "mxmake.topics:applications"
+i18n = "mxmake.topics:i18n"
 
 [build-system]
 requires = ["setuptools"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mxmake"
 description = "Generates a Python project-specific Makefile by using an extensible library of configurable Makefile snippets."
-version = "1.0a1.dev2"
+version = "1.0a1.dev3"
 keywords = ["development", "deployment", "environment"]
 authors = [
   {name = "MX Stack Developers", email = "dev@bluedynamics.com" }

--- a/src/mxmake/templates/additional_sources_targets.mk
+++ b/src/mxmake/templates/additional_sources_targets.mk
@@ -1,1 +1,1 @@
-ADDITIONAL_SOURCES_TARGETS={{ " ".join(additional_sources_targets) }}
+ADDITIONAL_SOURCES_TARGETS=$(wildcard {{ " ".join(additional_sources_targets) }})

--- a/src/mxmake/templates/dependencies.md
+++ b/src/mxmake/templates/dependencies.md
@@ -4,21 +4,22 @@
 
 flowchart TD
 {% for topic in topics %}
-{% for domain in topic.domains %}
-    {{ domain.fqn }}[{{ domain.title }}]
-{% endfor %}
-{% endfor %}
-{% for topic in topics %}
     subgraph {{ topic.title }}
 {% for domain in topic.domains %}
-{% for depends in domain.depends %}
-        {{ domain.fqn }} --> {{ depends }}
-{% endfor %}
-{% for depends in domain.soft_depends %}
-        {{ domain.fqn }} -.-> {{ depends }}
-{% endfor %}
+        {{ domain.fqn }}[{{ domain.title }}]
 {% endfor %}
     end
+{% endfor %}
+{% for topic in topics %}
+{% for domain in topic.domains %}
+    {{ domain.fqn }}[{{ domain.title }}]
+{% for depends in domain.depends %}
+    {{ domain.fqn }} --> {{ depends }}
+{% endfor %}
+{% for depends in domain.soft_depends %}
+    {{ domain.fqn }} -.-> {{ depends }}
+{% endfor %}
+{% endfor %}
 {% endfor %}
 
 ```

--- a/src/mxmake/tests/test_templates.py
+++ b/src/mxmake/tests/test_templates.py
@@ -381,7 +381,7 @@ class TestTemplates(testing.RenderTestCase):
 
         path = os.path.join(tempdir, "additional_sources_targets.mk")
         with open(path) as f:
-            self.checkOutput("ADDITIONAL_SOURCES_TARGETS=a b", f.read())
+            self.checkOutput("ADDITIONAL_SOURCES_TARGETS=$(wildcard a b)", f.read())
 
     @testing.temp_directory
     def test_Makefile(self, tempdir):

--- a/src/mxmake/topics.py
+++ b/src/mxmake/topics.py
@@ -304,3 +304,4 @@ system = Topic(name="system", directory=os.path.join(topics_dir, "system"))
 applications = Topic(
     name="applications", directory=os.path.join(topics_dir, "applications")
 )
+i18n = Topic(name="i18n", directory=os.path.join(topics_dir, "i18n"))

--- a/src/mxmake/topics/core/mxfiles.mk
+++ b/src/mxmake/topics/core/mxfiles.mk
@@ -47,22 +47,7 @@ else
 	@echo "[settings]" > $(PROJECT_CONFIG)
 endif
 
-LOCAL_PACKAGE_FILES:=
-ifneq ("$(wildcard pyproject.toml)","")
-	LOCAL_PACKAGE_FILES+=pyproject.toml
-endif
-ifneq ("$(wildcard setup.cfg)","")
-	LOCAL_PACKAGE_FILES+=setup.cfg
-endif
-ifneq ("$(wildcard setup.py)","")
-	LOCAL_PACKAGE_FILES+=setup.py
-endif
-ifneq ("$(wildcard requirements.txt)","")
-	LOCAL_PACKAGE_FILES+=requirements.txt
-endif
-ifneq ("$(wildcard constraints.txt)","")
-	LOCAL_PACKAGE_FILES+=constraints.txt
-endif
+LOCAL_PACKAGE_FILES:=$(wildcard pyproject.toml setup.cfg setup.py requirements.txt constraints.txt)
 
 FILES_TARGET:=requirements-mxdev.txt
 $(FILES_TARGET): $(PROJECT_CONFIG) $(MXENV_TARGET) $(SOURCES_TARGET) $(LOCAL_PACKAGE_FILES)

--- a/src/mxmake/topics/core/mxfiles.mk
+++ b/src/mxmake/topics/core/mxfiles.mk
@@ -57,6 +57,12 @@ endif
 ifneq ("$(wildcard setup.py)","")
 	LOCAL_PACKAGE_FILES+=setup.py
 endif
+ifneq ("$(wildcard requirements.txt)","")
+	LOCAL_PACKAGE_FILES+=requirements.txt
+endif
+ifneq ("$(wildcard constraints.txt)","")
+	LOCAL_PACKAGE_FILES+=constraints.txt
+endif
 
 FILES_TARGET:=requirements-mxdev.txt
 $(FILES_TARGET): $(PROJECT_CONFIG) $(MXENV_TARGET) $(SOURCES_TARGET) $(LOCAL_PACKAGE_FILES)

--- a/src/mxmake/topics/i18n/gettext.mk
+++ b/src/mxmake/topics/i18n/gettext.mk
@@ -1,0 +1,66 @@
+#:[gettext]
+#:title = Gettext
+#:description = Provide targets for working with gettext
+#:
+#:[target.gettext-create]
+#:description = Create message catalogs for all defined languages if not exists.
+#:
+#:[target.gettext-update]
+#:description = Update translations.
+#:
+#:[target.gettext-compile]
+#:description = Compile message catalogs.
+#:
+#:[setting.GETTEXT_LOCALES_PATH]
+#:description = Path of directory containing the message catalogs.
+#:default = locale
+#:
+#:[setting.GETTEXT_DOMAIN]
+#:description = Translation domain to use.
+#:default =
+#:
+#:[setting.GETTEXT_LANGUAGES]
+#:description = List of language identifiers.
+#:default =
+
+##############################################################################
+# gettext
+##############################################################################
+
+# case `system.dependencies` domain is included
+SYSTEM_DEPENDENCIES+=gettext
+
+.PHONY: gettext-create
+gettext-create:
+	@echo "Create message catalogs"
+	@for lang in "$(GETTEXT_LANGUAGES); do \
+		if [ ! -e "$(LOCALES_PATH)/$(lang)/LC_MESSAGES/$(DOMAIN).po" ]; then \
+			mkdir -p $(LOCALES_PATH)/$(lang)/LC_MESSAGES; \
+			msginit \
+				-i $(LOCALES_PATH)/$(DOMAIN).pot \
+				-o $(LOCALES_PATH)/$(lang)/LC_MESSAGES/$(DOMAIN).po \
+				-l $(lang); \
+		fi; \
+	done
+
+#.PHONY: gettext-update
+#gettext-update:
+#	@echo "Update translations"
+
+#echo "Update translations"
+#for po in "$LOCALES_PATH"/*/LC_MESSAGES/$DOMAIN.po; do
+#    msgmerge -o "$po" "$po" "$LOCALES_PATH"/$DOMAIN.pot
+#done
+
+#.PHONY: gettext-compile
+#gettext-compile:
+#	@echo "Compile message catalogs"
+
+#echo "Compile message catalogs"
+#for po in "$LOCALES_PATH"/*/LC_MESSAGES/*.po; do
+#	lg=${po##$LOCALES_PATH/}
+#	lg=${lg%%/LC_MESSAGES/*}
+#	echo -n "$lg: "
+#	msgfmt --statistics -o "${po%.*}.mo" "$po"
+#done
+

--- a/src/mxmake/topics/i18n/gettext.mk
+++ b/src/mxmake/topics/i18n/gettext.mk
@@ -57,15 +57,11 @@ gettext-update:
 			"$(GETTEXT_LOCALES_PATH)/$(GETTEXT_DOMAIN).pot"; \
 	done
 
-#.PHONY: gettext-compile
-#gettext-compile:
-#	@echo "Compile message catalogs"
-
-#echo "Compile message catalogs"
-#for po in "$GETTEXT_LOCALES_PATH"/*/LC_MESSAGES/*.po; do
-#	lg=${po##$GETTEXT_LOCALES_PATH/}
-#	lg=${lg%%/LC_MESSAGES/*}
-#	echo -n "$lg: "
-#	msgfmt --statistics -o "${po%.*}.mo" "$po"
-#done
-
+.PHONY: gettext-compile
+gettext-compile:
+	@echo "Compile message catalogs"
+	@for lang in $(GETTEXT_LANGUAGES); do \
+		msgfmt --statistics -o \
+			"$(GETTEXT_LOCALES_PATH)/$$lang/LC_MESSAGES/$(GETTEXT_DOMAIN).mo" \
+			"$(GETTEXT_LOCALES_PATH)/$$lang/LC_MESSAGES/$(GETTEXT_DOMAIN).po"; \
+	done

--- a/src/mxmake/topics/i18n/gettext.mk
+++ b/src/mxmake/topics/i18n/gettext.mk
@@ -34,15 +34,15 @@ SYSTEM_DEPENDENCIES+=gettext
 gettext-create:
 	@if [ ! -e "$(GETTEXT_LOCALES_PATH)/$(GETTEXT_DOMAIN).pot" ]; then \
 		echo "Create pot file"; \
-		mkdir -p $(GETTEXT_LOCALES_PATH); \
-		touch $(GETTEXT_LOCALES_PATH)/$(GETTEXT_DOMAIN).pot; \
+		mkdir -p "$(GETTEXT_LOCALES_PATH)"; \
+		touch "$(GETTEXT_LOCALES_PATH)/$(GETTEXT_DOMAIN).pot"; \
 	fi
 	@for lang in $(GETTEXT_LANGUAGES); do \
 		if [ ! -e "$(GETTEXT_LOCALES_PATH)/$$lang/LC_MESSAGES/$(GETTEXT_DOMAIN).po" ]; then \
-			mkdir -p $(GETTEXT_LOCALES_PATH)/$$lang/LC_MESSAGES; \
+			mkdir -p "$(GETTEXT_LOCALES_PATH)/$$lang/LC_MESSAGES"; \
 			msginit \
-				-i $(GETTEXT_LOCALES_PATH)/$(GETTEXT_DOMAIN).pot \
-				-o $(GETTEXT_LOCALES_PATH)/$$lang/LC_MESSAGES/$(GETTEXT_DOMAIN).po \
+				-i "$(GETTEXT_LOCALES_PATH)/$(GETTEXT_DOMAIN).pot" \
+				-o "$(GETTEXT_LOCALES_PATH)/$$lang/LC_MESSAGES/$(GETTEXT_DOMAIN).po" \
 				-l $$lang; \
 		fi \
 	done

--- a/src/mxmake/topics/i18n/gettext.mk
+++ b/src/mxmake/topics/i18n/gettext.mk
@@ -32,15 +32,19 @@ SYSTEM_DEPENDENCIES+=gettext
 
 .PHONY: gettext-create
 gettext-create:
-	@echo "Create message catalogs"
-	@for lang in "$(GETTEXT_LANGUAGES); do \
-		if [ ! -e "$(LOCALES_PATH)/$(lang)/LC_MESSAGES/$(DOMAIN).po" ]; then \
-			mkdir -p $(LOCALES_PATH)/$(lang)/LC_MESSAGES; \
+	@if [ ! -e "$(GETTEXT_LOCALES_PATH)/$(GETTEXT_DOMAIN).pot" ]; then \
+		echo "Create pot file"; \
+		mkdir -p $(GETTEXT_LOCALES_PATH); \
+		touch $(GETTEXT_LOCALES_PATH)/$(GETTEXT_DOMAIN).pot; \
+	fi
+	@for lang in $(GETTEXT_LANGUAGES); do \
+		if [ ! -e "$(GETTEXT_LOCALES_PATH)/$$lang/LC_MESSAGES/$(GETTEXT_DOMAIN).po" ]; then \
+			mkdir -p $(GETTEXT_LOCALES_PATH)/$$lang/LC_MESSAGES; \
 			msginit \
-				-i $(LOCALES_PATH)/$(DOMAIN).pot \
-				-o $(LOCALES_PATH)/$(lang)/LC_MESSAGES/$(DOMAIN).po \
-				-l $(lang); \
-		fi; \
+				-i $(GETTEXT_LOCALES_PATH)/$(GETTEXT_DOMAIN).pot \
+				-o $(GETTEXT_LOCALES_PATH)/$$lang/LC_MESSAGES/$(GETTEXT_DOMAIN).po \
+				-l $$lang; \
+		fi \
 	done
 
 #.PHONY: gettext-update
@@ -48,8 +52,8 @@ gettext-create:
 #	@echo "Update translations"
 
 #echo "Update translations"
-#for po in "$LOCALES_PATH"/*/LC_MESSAGES/$DOMAIN.po; do
-#    msgmerge -o "$po" "$po" "$LOCALES_PATH"/$DOMAIN.pot
+#for po in "$GETTEXT_LOCALES_PATH"/*/LC_MESSAGES/$GETTEXT_DOMAIN.po; do
+#    msgmerge -o "$po" "$po" "$GETTEXT_LOCALES_PATH"/$GETTEXT_DOMAIN.pot
 #done
 
 #.PHONY: gettext-compile
@@ -57,8 +61,8 @@ gettext-create:
 #	@echo "Compile message catalogs"
 
 #echo "Compile message catalogs"
-#for po in "$LOCALES_PATH"/*/LC_MESSAGES/*.po; do
-#	lg=${po##$LOCALES_PATH/}
+#for po in "$GETTEXT_LOCALES_PATH"/*/LC_MESSAGES/*.po; do
+#	lg=${po##$GETTEXT_LOCALES_PATH/}
 #	lg=${lg%%/LC_MESSAGES/*}
 #	echo -n "$lg: "
 #	msgfmt --statistics -o "${po%.*}.mo" "$po"

--- a/src/mxmake/topics/i18n/gettext.mk
+++ b/src/mxmake/topics/i18n/gettext.mk
@@ -47,14 +47,15 @@ gettext-create:
 		fi \
 	done
 
-#.PHONY: gettext-update
-#gettext-update:
-#	@echo "Update translations"
-
-#echo "Update translations"
-#for po in "$GETTEXT_LOCALES_PATH"/*/LC_MESSAGES/$GETTEXT_DOMAIN.po; do
-#    msgmerge -o "$po" "$po" "$GETTEXT_LOCALES_PATH"/$GETTEXT_DOMAIN.pot
-#done
+.PHONY: gettext-update
+gettext-update:
+	@echo "Update translations"
+	@for lang in $(GETTEXT_LANGUAGES); do \
+		msgmerge -o \
+			"$(GETTEXT_LOCALES_PATH)/$$lang/LC_MESSAGES/$(GETTEXT_DOMAIN).po" \
+			"$(GETTEXT_LOCALES_PATH)/$$lang/LC_MESSAGES/$(GETTEXT_DOMAIN).po" \
+			"$(GETTEXT_LOCALES_PATH)/$(GETTEXT_DOMAIN).pot"; \
+	done
 
 #.PHONY: gettext-compile
 #gettext-compile:

--- a/src/mxmake/topics/i18n/lingua.mk
+++ b/src/mxmake/topics/i18n/lingua.mk
@@ -38,7 +38,7 @@ lingua-extract: $(LINGUA_TARGET)
 		-o "$(GETTEXT_LOCALES_PATH)/$(GETTEXT_DOMAIN).pot"
 
 PHONY: lingua
-lingua: lingua-extract gettext-create gettext-update gettext-compile
+lingua: gettext-create lingua-extract gettext-update gettext-compile
 
 .PHONY: lingua-dirty
 lingua-dirty:

--- a/src/mxmake/topics/i18n/lingua.mk
+++ b/src/mxmake/topics/i18n/lingua.mk
@@ -1,7 +1,9 @@
 #:[lingua]
 #:title = Lingua
 #:description = Extract translatable texts from your code.
-#:depends = i18n.gettext
+#:depends =
+#:    core.mxenv
+#:    i18n.gettext
 #:
 #:[target.lingua-extract]
 #:description = Extract translatable texts from your code.

--- a/src/mxmake/topics/i18n/lingua.mk
+++ b/src/mxmake/topics/i18n/lingua.mk
@@ -25,15 +25,28 @@
 LINGUA_TARGET:=$(SENTINEL_FOLDER)/lingua.sentinel
 $(LINGUA_TARGET): $(MXENV_TARGET)
 	@echo "Install Lingua"
-	@$(MXENV_PATH)pip install lingua $(LINGUA_PLUGINS)
+	@$(MXENV_PATH)pip install chameleon lingua $(LINGUA_PLUGINS)
 	@touch $(LINGUA_TARGET)
 
 PHONY: lingua-extract
 lingua-extract: $(LINGUA_TARGET)
 	@echo "Extract messages"
-	@pot-create "$(LINGUA_SEARCH_PATH)" -o "$(GETTEXT_LOCALES_PATH)/$(GETTEXT_DOMAIN).pot"
+	@$(MXENV_PATH)pot-create \
+		"$(LINGUA_SEARCH_PATH)" \
+		-o "$(GETTEXT_LOCALES_PATH)/$(GETTEXT_DOMAIN).pot"
 
 PHONY: lingua
 lingua: lingua-extract gettext-create gettext-update gettext-compile
 
+.PHONY: lingua-dirty
+lingua-dirty:
+	@rm -f $(LINGUA_TARGET)
+
+.PHONY: lingua-clean
+lingua-clean: lingua-dirty
+	@test -e $(MXENV_PATH)pip && $(MXENV_PATH)pip uninstall -y \
+		chameleon lingua $(LINGUA_PLUGINS) || :
+
 INSTALL_TARGETS+=$(LINGUA_TARGET)
+DIRTY_TARGETS+=lingua-dirty
+CLEAN_TARGETS+=lingua-clean

--- a/src/mxmake/topics/i18n/lingua.mk
+++ b/src/mxmake/topics/i18n/lingua.mk
@@ -1,0 +1,2 @@
+# echo "Extract messages"
+# pot-create "$SEARCH_PATH" -o "$LOCALES_PATH"/$DOMAIN.pot

--- a/src/mxmake/topics/i18n/lingua.mk
+++ b/src/mxmake/topics/i18n/lingua.mk
@@ -1,2 +1,39 @@
-# echo "Extract messages"
-# pot-create "$SEARCH_PATH" -o "$LOCALES_PATH"/$DOMAIN.pot
+#:[lingua]
+#:title = Lingua
+#:description = Extract translatable texts from your code.
+#:depends = i18n.gettext
+#:
+#:[target.lingua-extract]
+#:description = Extract translatable texts from your code.
+#:
+#:[target.lingua]
+#:description = Extract translatable texts from your code and create,
+#:    update and compile message catalogs.
+#:
+#:[setting.LINGUA_SEARCH_PATH]
+#:description = Path of directory to extract translatable texts from.
+#:default = src
+#:
+#:[setting.LINGUA_PLUGINS]
+#:description = Python packages containing lingua extensions.
+#:default =
+
+##############################################################################
+# lingua
+##############################################################################
+
+LINGUA_TARGET:=$(SENTINEL_FOLDER)/lingua.sentinel
+$(LINGUA_TARGET): $(MXENV_TARGET)
+	@echo "Install Lingua"
+	@$(MXENV_PATH)pip install lingua $(LINGUA_PLUGINS)
+	@touch $(LINGUA_TARGET)
+
+PHONY: lingua-extract
+lingua-extract: $(LINGUA_TARGET)
+	@echo "Extract messages"
+	@pot-create "$(LINGUA_SEARCH_PATH)" -o "$(GETTEXT_LOCALES_PATH)/$(GETTEXT_DOMAIN).pot"
+
+PHONY: lingua
+lingua: lingua-extract gettext-create gettext-update gettext-compile
+
+INSTALL_TARGETS+=$(LINGUA_TARGET)

--- a/src/mxmake/topics/i18n/metadata.ini
+++ b/src/mxmake/topics/i18n/metadata.ini
@@ -1,0 +1,4 @@
+[metadata]
+title = i18n
+description = Contains domains for managing translations.
+

--- a/src/mxmake/topics/js/karma.mk
+++ b/src/mxmake/topics/js/karma.mk
@@ -27,4 +27,4 @@ NPM_DEV_PACKAGES+=\
 
 .PHONY: karma
 karma: $(NPM_TARGET)
-	@$(NPM_PREFIX)/node_modules/karma/bin/karma start $(KARMA_CONFIG) $(KARMA_OPTIONS)
+	@$(NPM_PREFIX)/node_modules/.bin/karma start $(KARMA_CONFIG) $(KARMA_OPTIONS)

--- a/src/mxmake/topics/js/npm.mk
+++ b/src/mxmake/topics/js/npm.mk
@@ -47,18 +47,29 @@ SYSTEM_DEPENDENCIES+=npm
 NPM_TARGET:=$(SENTINEL_FOLDER)/npm.sentinel
 $(NPM_TARGET): $(SENTINEL)
 	@echo "Install npm packages"
-ifneq ("$(NPM_PACKAGES)", "")
-	@npm install --prefix $(NPM_PREFIX) --no-save install $(NPM_PACKAGES)
-endif
-ifneq ("$(NPM_DEV_PACKAGES)", "")
-	@npm install --prefix $(NPM_PREFIX) --save-dev $(NPM_INSTALL_OPTS) install $(NPM_DEV_PACKAGES)
-endif
-ifneq ("$(NPM_PROD_PACKAGES)", "")
-	@npm install --prefix $(NPM_PREFIX) --save-prod $(NPM_INSTALL_OPTS) install $(NPM_PROD_PACKAGES)
-endif
-ifneq ("$(NPM_OPT_PACKAGES)", "")
-	@npm install --prefix $(NPM_PREFIX) --save-optional $(NPM_INSTALL_OPTS) install $(NPM_OPT_PACKAGES)
-endif
+	@test -z "$(NPM_PACKAGES)" \
+		&& echo "No packages to be installed" \
+		|| npm --prefix $(NPM_PREFIX) install \
+			--no-save \
+			$(NPM_PACKAGES)
+	@test -z "$(NPM_DEV_PACKAGES)" \
+		&& echo "No dev packages to be installed" \
+		|| npm --prefix $(NPM_PREFIX) install \
+			--save-dev \
+			$(NPM_INSTALL_OPTS) \
+			$(NPM_DEV_PACKAGES)
+	@test -z "$(NPM_PROD_PACKAGES)" \
+		&& echo "No prod packages to be installed" \
+		|| npm --prefix $(NPM_PREFIX) install \
+			--save-prod \
+			$(NPM_INSTALL_OPTS) \
+			$(NPM_PROD_PACKAGES)
+	@test -z "$(NPM_OPT_PACKAGES)" \
+		&& echo "No opt packages to be installed" \
+		|| npm --prefix $(NPM_PREFIX) install \
+			--save-optional \
+			$(NPM_INSTALL_OPTS) \
+			$(NPM_OPT_PACKAGES)
 	@touch $(NPM_TARGET)
 
 .PHONY: npm

--- a/src/mxmake/topics/js/npm.mk
+++ b/src/mxmake/topics/js/npm.mk
@@ -47,11 +47,6 @@ SYSTEM_DEPENDENCIES+=npm
 NPM_TARGET:=$(SENTINEL_FOLDER)/npm.sentinel
 $(NPM_TARGET): $(SENTINEL)
 	@echo "Install npm packages"
-	@test -z "$(NPM_PACKAGES)" \
-		&& echo "No packages to be installed" \
-		|| npm --prefix $(NPM_PREFIX) install \
-			--no-save \
-			$(NPM_PACKAGES)
 	@test -z "$(NPM_DEV_PACKAGES)" \
 		&& echo "No dev packages to be installed" \
 		|| npm --prefix $(NPM_PREFIX) install \
@@ -70,6 +65,11 @@ $(NPM_TARGET): $(SENTINEL)
 			--save-optional \
 			$(NPM_INSTALL_OPTS) \
 			$(NPM_OPT_PACKAGES)
+	@test -z "$(NPM_PACKAGES)" \
+		&& echo "No packages to be installed" \
+		|| npm --prefix $(NPM_PREFIX) install \
+			--no-save \
+			$(NPM_PACKAGES)
 	@touch $(NPM_TARGET)
 
 .PHONY: npm

--- a/src/mxmake/topics/js/rollup.mk
+++ b/src/mxmake/topics/js/rollup.mk
@@ -22,4 +22,4 @@ NPM_DEV_PACKAGES+=\
 
 .PHONY: rollup
 rollup: $(NPM_TARGET)
-	@$(NPM_PREFIX)/node_modules/rollup/dist/bin/rollup --config $(ROLLUP_CONFIG)
+	@$(NPM_PREFIX)/node_modules/.bin/rollup --config $(ROLLUP_CONFIG)

--- a/src/mxmake/topics/js/rollup.mk
+++ b/src/mxmake/topics/js/rollup.mk
@@ -18,7 +18,7 @@
 NPM_DEV_PACKAGES+=\
 	rollup \
 	rollup-plugin-cleanup \
-	rollup-plugin-terser
+	@rollup/plugin-terser
 
 .PHONY: rollup
 rollup: $(NPM_TARGET)

--- a/src/mxmake/topics/js/scss.mk
+++ b/src/mxmake/topics/js/scss.mk
@@ -1,0 +1,31 @@
+#:[scss]
+#:title = SCSS Compiler
+#:description = Compile Stylesheets using SCSS.
+#:depends = js.npm
+#:
+#:[target.scss]
+#:description = Run SCSS Stylesheet Compiler.
+#:
+#:[setting.SCSS_SOURCE]
+#:description = The SCSS root source file.
+#:default = scss/styles.scss
+#:
+#:[setting.SCSS_TARGET]
+#:description = The target file for the compiles Stylesheet.
+#:default = scss/styles.css
+#:
+#:[setting.SCSS_OPTIONS]
+#:description = Additional options to be passed to SCSS compiler.
+#:default = --no-source-map=none
+
+##############################################################################
+# scss
+##############################################################################
+
+# extend npm dev packages
+NPM_DEV_PACKAGES+=sass
+
+.PHONY: scss
+scss: $(NPM_TARGET)
+	@$(NPM_PREFIX)/node_modules/.bin/sass \
+		$(SCSS_OPTIONS) $(SCSS_SOURCE) $(SCSS_TARGET)

--- a/src/mxmake/topics/qa/zpretty.mk
+++ b/src/mxmake/topics/qa/zpretty.mk
@@ -29,16 +29,13 @@ $(ZPRETTY_TARGET): $(MXENV_TARGET)
 
 .PHONY: zpretty-check
 zpretty-check: $(ZPRETTY_TARGET)
-	@echo "Run zpretty check"
-	@echo "find $(ZPRETTY_SRC) -name '*.zcml' -or -name '*.xml' -exec $(MXENV_PATH)zpretty -i {} +""
-	@find $(ZPRETTY_SRC) -name '*.zcml' -or -name '*.xml' -exec $(MXENV_PATH)zpretty -i {} +
-	@$(MXENV_PATH)zpretty --check $(ZPRETTY_SRC)
+	@echo "Run zpretty check in: $(ZPRETTY_SRC)"
+	@find $(ZPRETTY_SRC) -name '*.zcml' -or -name '*.xml' -exec $(MXENV_PATH)zpretty --check {} +
 
 .PHONY: zpretty-format
 zpretty-format: $(ZPRETTY_TARGET)
-	@echo "Run zpretty format"
-	@find $(ZPRETTY_SRC) -name '*.zcml' -or -name '*.xml' -exec $(MXENV_PATH)zpretty --check {} +
-	@$(MXENV_PATH)zpretty $(ZPRETTY_SRC)
+	@echo "Run zpretty format in: $(ZPRETTY_SRC)"
+	@find $(ZPRETTY_SRC) -name '*.zcml' -or -name '*.xml' -exec $(MXENV_PATH)zpretty -i {} +
 
 .PHONY: zpretty-dirty
 zpretty-dirty:


### PR DESCRIPTION
- [ ] Extend topics/domains:
    - [ ] Create `webpack` domain in `js` topic
    - [x] Create `scss` domain in `js` topic
    - [x] Create `gettext` domain in `i18n` topic
    - [x] Create `lingua` domain in `i18n` topic
- [ ] Currently test and coverage script generation targets `zope-testrunner` support `pytest` and `unittest`.
- [ ] Implement custom template generation configured via `mx.ini`
- [ ] Consider local package in generated `test` and `coverage` scripts.
- [ ] Complete docs
- [ ]  additional target `START_TARGET` to append there services run on make start
- [ ] Add help targets