### PR TITLE
Ongoing Development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mxmake"
 description = "Generates a Python project-specific Makefile by using an extensible library of configurable Makefile snippets."
-version = "1.0a1.dev3"
+version = "1.0a1.dev4"
 keywords = ["development", "deployment", "environment"]
 authors = [
   {name = "MX Stack Developers", email = "dev@bluedynamics.com" }


### PR DESCRIPTION
- [ ] Extend topics/domains:
    - [ ] Create `webpack` domain in `js` topic
- [ ] Currently test and coverage script generation targets `zope-testrunner` support `pytest` and `unittest`.
- [ ] Implement custom template generation configured via `mx.ini`
- [ ] Consider local package in generated `test` and `coverage` scripts.
- [ ] Complete docs
- [ ]  additional target `START_TARGET` to append there services run on make start
- [ ] Add help targets