### PR TITLE
Depend on mxdev>=4.0.2, which fixes the deprecation of pkg_resources …

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,7 @@
 
 ## 1.0a5 (unreleased)
 
-
-- Nothing changed yet.
-
+- Depend on `mxdev>=4.0.2`, which fixes the deprecation of `pkg_resources` and use the provided infrastructure of mxdev to handle entry_points in mxmake.
 
 ## 1.0a4 (2024-03-12)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,13 +2,18 @@
 
 ## 1.0a5 (unreleased)
 
-- Depend on `mxdev>=4.0.2`, which fixes the deprecation of `pkg_resources` and use the provided infrastructure of mxdev to handle entry_points in mxmake.
+- Add `Makefile` as dependency target for `SENTINEL` target to make sure
+  target execution if Makefile changes.
+
+- Depend on `mxdev>=4.0.2`, which fixes the deprecation of `pkg_resources` and
+  use the provided infrastructure of mxdev to handle entry_points in mxmake.
 
 ## 1.0a4 (2024-03-12)
 
 - Add experimental windows support.
 
-- Support `mxmake update` command, updating the Makefile without prompting for settings.
+- Support `mxmake update` command, updating the Makefile without prompting for
+  settings.
 
 - Use importlib.metadata to load entrypoints.
 
@@ -29,7 +34,8 @@
 
 - Rename `PYTHON_BIN` to `PRIMARY_PYTHON` in `mxenv` domain.
 
-- Introduce `MXENV_PYTHON`. It defines the Python executable used for mxmake operations.
+- Introduce `MXENV_PYTHON`. It defines the Python executable used for mxmake
+  operations.
 
 - Remove ruff cache when running `make ruff-clean` target.
 
@@ -39,8 +45,9 @@
 
 - Add pyupgrade based code formatter, see https://pypi.org/project/pyupgrade/.
 
-- Add `ZOPE_TEMPLATE_CHECKOUT` option to zope domain to allow pinning to a tag, branch or revision (uses cookiecutter `--checkout`).
-  If empty, do not apply `--checkout` option.
+- Add `ZOPE_TEMPLATE_CHECKOUT` option to zope domain to allow pinning to a tag,
+  branch or revision (uses cookiecutter `--checkout`). If empty, do not apply
+  `--checkout` option.
 
 - Add phony target `cookiecutter` to be able to just install it.
 

--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,7 @@ MXMAKE_FOLDER?=.mxmake
 # Sentinel files
 SENTINEL_FOLDER?=$(MXMAKE_FOLDER)/sentinels
 SENTINEL?=$(SENTINEL_FOLDER)/about.txt
-$(SENTINEL):
+$(SENTINEL): Makefile
 	@mkdir -p $(SENTINEL_FOLDER)
 	@echo "Sentinels for the Makefile process." > $(SENTINEL)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "Jinja2",
-    "mxdev",
+    "mxdev>=4.0.2",
     "inquirer",
 ]
 dynamic = ["readme"]

--- a/src/mxmake/tests/test_templates.py
+++ b/src/mxmake/tests/test_templates.py
@@ -654,10 +654,11 @@ class TestTemplates(testing.RenderTestCase):
                  # Sentinel files
                 SENTINEL_FOLDER?=$(MXMAKE_FOLDER)/sentinels
                 SENTINEL?=$(SENTINEL_FOLDER)/about.txt
-                $(SENTINEL):
+                $(SENTINEL): Makefile
                 	@mkdir -p $(SENTINEL_FOLDER)
                 	@echo "Sentinels for the Makefile process." > $(SENTINEL)
-                 ##############################################################################
+
+                ##############################################################################
                 # mxenv
                 ##############################################################################
 

--- a/src/mxmake/tests/test_templates.py
+++ b/src/mxmake/tests/test_templates.py
@@ -654,7 +654,7 @@ class TestTemplates(testing.RenderTestCase):
                  # Sentinel files
                 SENTINEL_FOLDER?=$(MXMAKE_FOLDER)/sentinels
                 SENTINEL?=$(SENTINEL_FOLDER)/about.txt
-                $(SENTINEL): Makefile
+                $(SENTINEL): $(firstword $(MAKEFILE_LIST))
                 	@mkdir -p $(SENTINEL_FOLDER)
                 	@echo "Sentinels for the Makefile process." > $(SENTINEL)
 

--- a/src/mxmake/topics.py
+++ b/src/mxmake/topics.py
@@ -1,6 +1,6 @@
 from collections import Counter
 from dataclasses import dataclass
-from importlib.metadata import entry_points
+from mxdev.entry_points import load_eps_by_group
 from pathlib import Path
 
 import configparser
@@ -8,15 +8,6 @@ import functools
 import io
 import operator
 import typing
-
-
-try:
-    # do we have Python 3.12+
-    from importlib.metadata import EntryPoints  # type: ignore # noqa: F401
-
-    HAS_IMPORTLIB_ENTRYPOINTS = True
-except ImportError:
-    HAS_IMPORTLIB_ENTRYPOINTS = False
 
 
 @dataclass
@@ -174,17 +165,7 @@ class Topic:
 
 @functools.lru_cache(maxsize=4096)
 def load_topics() -> typing.List[Topic]:
-    if HAS_IMPORTLIB_ENTRYPOINTS:
-        topics_eps = entry_points(group="mxmake.topics")  # type: ignore
-    else:
-        eps = entry_points()
-        if "mxmake.topics" not in eps:
-            return []
-        topics_eps = eps["mxmake.topics"]  # type: ignore
-    # XXX: for some reasons entry points are loaded twice. not sure if this
-    #      is a glitch when installing with uv or something related to
-    #      importlib.metadata.entry_points
-    return list(set([ep.load() for ep in topics_eps]))  # type: ignore
+    return [ep.load() for ep in load_eps_by_group("mxmake.topics")]  # type: ignore
 
 
 def get_topic(name: str) -> Topic:

--- a/src/mxmake/topics/core/base.mk
+++ b/src/mxmake/topics/core/base.mk
@@ -72,6 +72,6 @@ MXMAKE_FOLDER?=.mxmake
 # Sentinel files
 SENTINEL_FOLDER?=$(MXMAKE_FOLDER)/sentinels
 SENTINEL?=$(SENTINEL_FOLDER)/about.txt
-$(SENTINEL): Makefile
+$(SENTINEL): $(firstword $(MAKEFILE_LIST))
 	@mkdir -p $(SENTINEL_FOLDER)
 	@echo "Sentinels for the Makefile process." > $(SENTINEL)

--- a/src/mxmake/topics/core/base.mk
+++ b/src/mxmake/topics/core/base.mk
@@ -72,6 +72,6 @@ MXMAKE_FOLDER?=.mxmake
 # Sentinel files
 SENTINEL_FOLDER?=$(MXMAKE_FOLDER)/sentinels
 SENTINEL?=$(SENTINEL_FOLDER)/about.txt
-$(SENTINEL):
+$(SENTINEL): Makefile
 	@mkdir -p $(SENTINEL_FOLDER)
 	@echo "Sentinels for the Makefile process." > $(SENTINEL)


### PR DESCRIPTION
…and use the provided infrastructure of mxdev to handle entry_points in mxmake.