### PR TITLE
first basic impl of a help system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 # DOMAINS:
 #: applications.zest-releaser
 #: core.base
+#: core.help
 #: core.mxenv
 #: core.mxfiles
 #: core.packages
@@ -50,7 +51,7 @@ EXTRA_PATH?=
 PRIMARY_PYTHON?=python3
 
 # Minimum required Python version.
-# Default: 3.7
+# Default: 3.9
 PYTHON_MIN_VERSION?=3.9
 
 # Install packages using the given package installer method.
@@ -165,6 +166,12 @@ MYPY_SRC?=src
 # Mypy Python requirements to be installed (via pip).
 # Default: types-setuptools
 MYPY_REQUIREMENTS?=types-setuptools types-docutils types-PyYAML
+
+## core.help
+
+# Request to show all targets, descriptions and arguments for a given domain.
+# No default value.
+HELP_DOMAIN?=
 
 ## applications.zest-releaser
 
@@ -595,6 +602,14 @@ CLEAN_TARGETS+=mypy-clean
 DIRTY_TARGETS+=mypy-dirty
 
 ##############################################################################
+# help
+##############################################################################
+
+.PHONY: help
+help: $(MXENV_TARGET)
+	@mxmake help-generator
+
+##############################################################################
 # zest-releaser
 ##############################################################################
 
@@ -635,6 +650,10 @@ zest-releaser-clean: zest-releaser-dirty
 INSTALL_TARGETS+=$(ZEST_RELEASER_TARGET)
 DIRTY_TARGETS+=zest-releaser-dirty
 CLEAN_TARGETS+=zest-releaser-clean
+
+##############################################################################
+# Custom includes
+##############################################################################
 
 -include $(INCLUDE_MAKEFILE)
 

--- a/src/mxmake/helpgen.py
+++ b/src/mxmake/helpgen.py
@@ -1,0 +1,93 @@
+from .parser import MakefileParser
+from .topics import get_domain
+from .topics import get_topic
+from .topics import resolve_domain_dependencies
+from .topics import set_domain_runtime_depends
+
+import os
+import sys
+import textwrap
+
+
+def print_help(makefile: "pathlib.Path"):
+    """Parse the Makefile and print the help."""
+
+    parser = MakefileParser(makefile)
+
+    sys.stdout.write("\nUsage: make <target> [ARGUMENT1=value1] [ARGUMENT2=value2]\n\n")
+    help_domain = os.environ.get("HELP_DOMAIN")
+    if help_domain:
+        sys.stdout.write(f"Help for domain '{help_domain}'\n\n")
+    else:
+        sys.stdout.write("Available targets:\n\n")
+
+    domains = [get_domain(fqn) for fqn in parser.fqns]
+    set_domain_runtime_depends(domains)
+    idnt = "    "
+    lvl = 1
+    found = False
+    for domain in resolve_domain_dependencies(domains):
+        if help_domain and domain.name != help_domain:
+            continue
+        topic = get_topic(domain.topic)
+        sys.stdout.write(
+            f"DOMAIN '{domain.name}' (topic {topic.title})\n"
+        )
+        sys.stdout.write(
+            "\n".join(
+                textwrap.wrap(
+                    domain.description,
+                    width=79,
+                    initial_indent=idnt * lvl,
+                    subsequent_indent=idnt * lvl,
+                )
+            )
+        )
+        sys.stdout.write("\n\nTARGETS\n\n")
+        for target in domain.targets:
+            sys.stdout.write(f"{idnt*lvl}{target.name}\n")
+            if help_domain:
+                lvl += 1
+                found = True
+                sys.stdout.write(
+                    "\n".join(
+                        textwrap.wrap(
+                            target.description,
+                            width=79,
+                            initial_indent=idnt * (lvl),
+                            subsequent_indent=idnt * (lvl),
+                        )
+                    )
+                )
+                sys.stdout.write("\n\n")
+                lvl -= 1
+        if help_domain:
+            sys.stdout.write(f"ARGUMENTS\n\n")
+            for setting in domain.settings:
+                fqn_setting = f"{domain.fqn}.{setting.name}"
+                sys.stdout.write(
+                    f"{idnt*lvl}{setting.name}={parser.settings.get(fqn_setting) or '<not set>'}\n"
+                )
+                sys.stdout.write(
+                    "\n".join(
+                        textwrap.wrap(
+                            setting.description,
+                            width=79,
+                            initial_indent=idnt * (lvl + 1),
+                            subsequent_indent=idnt * (lvl + 1),
+                        )
+                    )
+                )
+                sys.stdout.write("\n\n")
+        else:
+            sys.stdout.write("\n\n")
+
+
+    if not help_domain:
+        sys.stdout.write("")
+        sys.stdout.write(
+            "Need detailed help by domain containing all information?\nRun:\n\n    make help HELP_DOMAIN=<domain>\n"
+        )
+    elif not found:
+        sys.stdout.write("No help found for requested domain st\n")
+        sys.exit(1)

--- a/src/mxmake/helpgen.py
+++ b/src/mxmake/helpgen.py
@@ -5,11 +5,12 @@ from .topics import resolve_domain_dependencies
 from .topics import set_domain_runtime_depends
 
 import os
+import pathlib
 import sys
 import textwrap
 
 
-def print_help(makefile: "pathlib.Path"):
+def print_help(makefile: pathlib.Path):
     """Parse the Makefile and print the help."""
 
     parser = MakefileParser(makefile)
@@ -30,9 +31,7 @@ def print_help(makefile: "pathlib.Path"):
         if help_domain and domain.name != help_domain:
             continue
         topic = get_topic(domain.topic)
-        sys.stdout.write(
-            f"DOMAIN '{domain.name}' (topic {topic.title})\n"
-        )
+        sys.stdout.write(f"DOMAIN '{domain.name}' (topic {topic.title})\n")
         sys.stdout.write(
             "\n".join(
                 textwrap.wrap(
@@ -62,7 +61,7 @@ def print_help(makefile: "pathlib.Path"):
                 sys.stdout.write("\n\n")
                 lvl -= 1
         if help_domain:
-            sys.stdout.write(f"ARGUMENTS\n\n")
+            sys.stdout.write("ARGUMENTS\n\n")
             for setting in domain.settings:
                 fqn_setting = f"{domain.fqn}.{setting.name}"
                 sys.stdout.write(
@@ -81,7 +80,6 @@ def print_help(makefile: "pathlib.Path"):
                 sys.stdout.write("\n\n")
         else:
             sys.stdout.write("\n\n")
-
 
     if not help_domain:
         sys.stdout.write("")

--- a/src/mxmake/main.py
+++ b/src/mxmake/main.py
@@ -1,14 +1,15 @@
-from mxmake.parser import MakefileParser
-from mxmake.templates import ci_template
-from mxmake.templates import get_template_environment
-from mxmake.templates import template
-from mxmake.topics import collect_missing_dependencies
-from mxmake.topics import Domain
-from mxmake.topics import get_domain
-from mxmake.topics import get_topic
-from mxmake.topics import load_topics
-from mxmake.topics import resolve_domain_dependencies
-from mxmake.topics import set_domain_runtime_depends
+from .helpgen import print_help
+from .parser import MakefileParser
+from .templates import ci_template
+from .templates import get_template_environment
+from .templates import template
+from .topics import collect_missing_dependencies
+from .topics import Domain
+from .topics import get_domain
+from .topics import get_topic
+from .topics import load_topics
+from .topics import resolve_domain_dependencies
+from .topics import set_domain_runtime_depends
 from operator import attrgetter
 from pathlib import Path
 from textwrap import indent
@@ -301,15 +302,30 @@ def update_command(args: argparse.Namespace):
     sys.stdout.write("###############\n\n")
 
     if not Path("Makefile").exists():
-        sys.stdout.write("Makefile not exists, abort\n")
+        sys.stdout.write("Makefile does not exist, abort\n")
         sys.exit(1)
 
     create_config(prompt=False, preseeds=None)
 
 
-update_parser = command_parsers.add_parser("update", help="Update makefile")
+update_parser = command_parsers.add_parser("update", help="Update Makefile")
 update_parser.set_defaults(func=update_command)
 
+
+def help_generator_command(args: argparse.Namespace):
+    sys.stdout.write("Help for Makefile\n")
+    makefile = Path("Makefile")
+    if not makefile.exists():
+        sys.stdout.write("Makefile does not exist, abort\n")
+        sys.exit(1)
+
+    print_help(makefile)
+
+
+help_generator_parser = command_parsers.add_parser(
+    "help-generator", help="Help for Makefile"
+)
+help_generator_parser.set_defaults(func=help_generator_command)
 
 ##############################################################################
 # main

--- a/src/mxmake/templates.py
+++ b/src/mxmake/templates.py
@@ -546,21 +546,18 @@ class ProxyMk(MxIniBoundTemplate):
     def template_variables(self):
         targets = []
         for folder, proxy in self.settings.items():
-            for item in [item.strip() for item in proxy.split('\n') if item.strip()]:
-                topic_name, domain_names = item.split(':')
+            for item in [item.strip() for item in proxy.split("\n") if item.strip()]:
+                topic_name, domain_names = item.split(":")
                 topic = get_topic(topic_name.strip())
-                domain_names = domain_names.split(',')
+                domain_names = domain_names.split(",")
                 domains = []
                 for domain_name in domain_names:
-                    if domain_name == '*':
+                    if domain_name == "*":
                         domains = topic.domains
                         break
                     else:
                         domains.append(topic.domain(domain_name.strip()))
                 for domain in domains:
                     for target in domain.targets:
-                        targets.append(dict(
-                            name=target.name,
-                            folder=folder
-                        ))
+                        targets.append(dict(name=target.name, folder=folder))
         return dict(targets=targets)

--- a/src/mxmake/tests/test_templates.py
+++ b/src/mxmake/tests/test_templates.py
@@ -965,28 +965,33 @@ class TestTemplates(testing.RenderTestCase):
         factory = templates.template.lookup("proxy")
         template = factory(configuration, templates.get_template_environment())
 
-        self.assertEqual(template.description, "Contains proxy targets for Makefiles of source folders")
+        self.assertEqual(
+            template.description,
+            "Contains proxy targets for Makefiles of source folders",
+        )
         self.assertEqual(template.target_folder, utils.mxmake_files())
         self.assertEqual(template.target_name, "proxy.mk")
         self.assertEqual(template.template_name, "proxy.mk")
         self.assertEqual(
             template.template_variables,
-            {'targets': [
-                {'name': 'plone-site-create', 'folder': 'folder'},
-                {'name': 'plone-site-purge', 'folder': 'folder'},
-                {'name': 'plone-site-recreate', 'folder': 'folder'},
-                {'name': 'gettext-create', 'folder': 'folder'},
-                {'name': 'gettext-update', 'folder': 'folder'},
-                {'name': 'gettext-compile', 'folder': 'folder'},
-                {'name': 'lingua-extract', 'folder': 'folder'},
-                {'name': 'lingua', 'folder': 'folder'}
-            ]}
+            {
+                "targets": [
+                    {"name": "plone-site-create", "folder": "folder"},
+                    {"name": "plone-site-purge", "folder": "folder"},
+                    {"name": "plone-site-recreate", "folder": "folder"},
+                    {"name": "gettext-create", "folder": "folder"},
+                    {"name": "gettext-update", "folder": "folder"},
+                    {"name": "gettext-compile", "folder": "folder"},
+                    {"name": "lingua-extract", "folder": "folder"},
+                    {"name": "lingua", "folder": "folder"},
+                ]
+            },
         )
 
         template.write()
         with (tempdir / "proxy.mk").open() as f:
             self.checkOutput(
-                '''
+                """
                 ##############################################################################
                 # proxy targets
                 ##############################################################################
@@ -1023,6 +1028,6 @@ class TestTemplates(testing.RenderTestCase):
                 folder-lingua:
                 	$(MAKE) -C "./folder/" lingua
 
-                ''',
+                """,
                 f.read(),
             )

--- a/src/mxmake/topics/core/base.mk
+++ b/src/mxmake/topics/core/base.mk
@@ -10,8 +10,16 @@
 #:description = Deploy project. Supposed to setup a production version of
 #:  the project.
 #:
+#:[setting.DEPLOY_TARGETS]
+#:description = `deploy` target dependencies.
+#:default =
+#:
 #:[target.run]
 #:description = Run project. Depending on target defined in `RUN_TARGET`
+#:
+#:[setting.RUN_TARGET]
+#:description = target to be executed when calling `make run`
+#:default =
 #:
 #:[target.dirty]
 #:description = Force make to rebuild targets on next make run.
@@ -27,21 +35,21 @@
 #:[target.runtime-clean]
 #:description = Remove runtime artifacts, like byte-code and caches.
 #:
-#:[target.check]
-#:description = Run all QA related targets, e.g. code style or type checks.
-#:  Only gets included if any qa topic related domain is used.
-#:
-#:[setting.DEPLOY_TARGETS]
-#:description = `deploy` target dependencies.
-#:default =
-#:
-#:[setting.RUN_TARGET]
-#:description = target to be executed when calling `make run`
-#:default =
-#:
 #:[setting.CLEAN_FS]
 #:description = Additional files and folders to remove when running clean target
 #:default =
+#:
+#:[target.check]
+#:description = Run all QA checkers related targets, e.g. code style
+#:  Only gets included if any qa topic related domain is used.
+#:
+#:[target.type-check]
+#:description = Run all QA type-checkers related targets, e.g. type checks.
+#:  Only gets included if any qa topic related domain is used.
+#:
+#:[target.format]
+#:description = Run all QA code formatters related targets, e.g. code style
+#:  Only gets included if any qa topic related domain is used.
 #:
 #:[setting.INCLUDE_MAKEFILE]
 #:description = Optional makefile to include before default targets. This can

--- a/src/mxmake/topics/core/help.mk
+++ b/src/mxmake/topics/core/help.mk
@@ -1,0 +1,22 @@
+#:[help]
+#:title = Help System
+#:description = A system to provide the user of the Makefile an overview of the targets
+#:              and all environment variable based arguments.
+#:
+#:depends = core.mxenv
+#:
+#:[target.help]
+#:description = Print help for the Makefile.
+#:
+#:[setting.HELP_DOMAIN]
+#:description = Request to show all targets, descriptions and arguments for a given domain.
+#:default =
+#:
+
+##############################################################################
+# help
+##############################################################################
+
+.PHONY: help
+help: $(MXENV_TARGET)
+	@mxmake help-generator


### PR DESCRIPTION
Adds a `make help` or `make help HELP_DOMAIN=<domain>` (like `make help HELP_DOMAIN=zope`).
In the first case a comprehensive overview of all commands (phony targets) is printed (sorted by domain), in latter all details with descriptions and configurations via environment variables is printed. 

We may want to add a `make help_all` , but this would be a long output.